### PR TITLE
create-rb-port: Improve dependency handling

### DIFF
--- a/create-rb-port
+++ b/create-rb-port
@@ -102,8 +102,15 @@ File.open('Makefile', 'w') do |f|
         else
             f.print "\t\t"
         end
-        f.puts "rubygem-#{d.name}>=#{version}:CATEGORY/rubygem-#{d.name}"
+        f.print "rubygem-#{d.name}>=#{version}:CATEGORY/rubygem-#{d.name}"
+        if d != s.dependencies.last
+            f.puts " \\"
+	else
+            f.puts ""
+        end
+
     end
+    f.puts ""
     f.puts "USE_RUBY=\tyes"
     f.puts "USES=\t\tgem"
     f.puts


### PR DESCRIPTION
- Terminate dependencies with \ except for the last
- Add empty line in between